### PR TITLE
fix: 虚拟列表仅在真实加载时显示骨架并补齐 API 文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -1512,7 +1512,9 @@ render(<BaseExample />);
 | children | ReactNode | '文件上传' | 上传按钮文字 |
 | renderTips | function(defaultTips, { fileSize, maxLength, accept }) | v => v | 自定义提示信息渲染 |
 | onSave | function(data, file, uuid) | - | 上传成功后数据处理回调，返回值将作为新的文件对象 |
-| ossUpload | function | - | 自定义上传函数 |
+| onUpload | function({ file, path? }) | - | 自定义上传函数；优先于 `ossUpload` / preset `apis.file.upload` |
+| ossUpload | function | - | 自定义上传函数（兼容旧写法，等价于 `onUpload`） |
+| directory | string | - | 上传目录；内部映射为后端 `path` 传给上传接口 |
 | getPermission | function(type) | - | 文件列表操作权限控制函数，type为'preview'/'delete'等 |
 | apis | object | - | API配置对象 |
 | renderModal | function(modalProps) | props => Modal | 自定义弹窗渲染函数 |
@@ -1807,9 +1809,12 @@ ZIP压缩包文件预览组件，支持查看压缩包内部的文件列表和�
 | entries | array | - | 异步分页：当前目录稀疏数组（`length === totalCount`，未加载为 empty） |
 | totalCount | number | - | 异步分页：当前目录总数量；与 `onVisibleRangeChange` 同时传入即开启虚拟滚动 |
 | loadingIndexes | Set \| array | - | 异步分页：正在加载的下标，显示骨架占位 |
-| onVisibleRangeChange | function(range) | - | 异步分页：可视范围变化；`range` 含 `startIndex` / `endIndex` / `view` / `viewport` / `pageSize` / `currentPath` / `keyword` |
+| ready | boolean | - | 异步分页：当前目录是否已确认首屏数据；`false` 时即使 `totalCount === 0` 仍挂载虚拟列表以测量视口；未传时保持旧逻辑 |
+| columnListings | object | - | 异步分页（分栏）：按目录 path 隔离的列表数据，形如 `{ [path]: { entries, totalCount, loadingIndexes?, ready? } }`；展开列从这里读，避免只靠当前目录 `entries` |
+| onRegisterFolder | function(path, id) | - | 分栏单击文件夹展开下一列时回调；用于业务侧登记 folderId 与 path 的映射 |
+| onVisibleRangeChange | function(range) | - | 异步分页：可视范围变化。`range` 含：`startIndex` / `endIndex` / `view` / `viewport` / `pageSize` / `currentPath` / `keyword` / `path` / `columnPath`。分栏展开列以 `columnPath`（或合并后的 `path`）为准拉目录；其它视图 `path` 等于 `currentPath` |
 
-`FileSystem.calcPageSize({ view, width, height })` 可按视口估算建议 `perPage`。
+`calcPageSize({ view, width, height, buffer? })` 可按视口估算建议 `perPage`（也可写作 `FileSystem.calcPageSize`）。`view` 为 `icons` / `list` / `columns` / `gallery`；`buffer` 默认 `2`，结果夹在 20–200。
 
 #### FileSystem.PropertiesPanel
 
@@ -1890,6 +1895,50 @@ const MyComponent = withOSSFile(({ data, id, ...props }) => {
 
 ---
 
+### uploadFile
+
+统一上传入口。库内上传应走此 API；会解析自定义 `onUpload` 或 preset `apis.file.upload` / `ossUpload` / `upload`，并将 `directory` 映射为后端 `path`。
+
+#### 参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| file | File | - | 待上传文件 |
+| directory | string | - | 上传目录，映射为请求体 `path` |
+| onUpload | function({ file, path? }) | - | 自定义上传函数；不传则读 `apis` |
+| apis | object | - | API 配置；默认取自 preset |
+
+#### 返回值
+
+上传接口的原始返回值（通常为 `{ data: { code, data, msg } }` 形态，由业务 `apis.file.upload` 决定）。
+
+```jsx
+import { uploadFile } from '@kne/react-file';
+
+await uploadFile({ file, directory: 'docs/2026' });
+```
+
+---
+
+### useUploadFile
+
+返回绑定当前 preset `apis` 的 `uploadFile` 函数，便于在组件内直接调用。
+
+#### 返回值
+
+| 类型 | 描述 |
+|------|------|
+| function(params) | 同 `uploadFile`；可再传 `apis` 覆盖 preset |
+
+```jsx
+import { useUploadFile } from '@kne/react-file';
+
+const upload = useUploadFile();
+await upload({ file, directory: 'avatars' });
+```
+
+---
+
 ### useFileUpload
 
 文件上传Hook，处理文件上传逻辑。
@@ -1907,7 +1956,8 @@ const MyComponent = withOSSFile(({ data, id, ...props }) => {
 | onError | function({ file, error, errMsg }) | - | 上传失败回调 |
 | onSave | function(data, file, uuid) | - | 上传成功后数据处理回调 |
 | onChange | function(list) | - | 文件列表变化回调 |
-| onUpload | function({ file }) | - | 自定义上传函数 |
+| onUpload | function({ file, path? }) | - | 自定义上传函数 |
+| directory | string | - | 上传目录；内部映射为后端 `path` |
 
 #### 返回值
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -37,7 +37,9 @@
 | children | ReactNode | '文件上传' | 上传按钮文字 |
 | renderTips | function(defaultTips, { fileSize, maxLength, accept }) | v => v | 自定义提示信息渲染 |
 | onSave | function(data, file, uuid) | - | 上传成功后数据处理回调，返回值将作为新的文件对象 |
-| ossUpload | function | - | 自定义上传函数 |
+| onUpload | function({ file, path? }) | - | 自定义上传函数；优先于 `ossUpload` / preset `apis.file.upload` |
+| ossUpload | function | - | 自定义上传函数（兼容旧写法，等价于 `onUpload`） |
+| directory | string | - | 上传目录；内部映射为后端 `path` 传给上传接口 |
 | getPermission | function(type) | - | 文件列表操作权限控制函数，type为'preview'/'delete'等 |
 | apis | object | - | API配置对象 |
 | renderModal | function(modalProps) | props => Modal | 自定义弹窗渲染函数 |
@@ -332,9 +334,12 @@ ZIP压缩包文件预览组件，支持查看压缩包内部的文件列表和�
 | entries | array | - | 异步分页：当前目录稀疏数组（`length === totalCount`，未加载为 empty） |
 | totalCount | number | - | 异步分页：当前目录总数量；与 `onVisibleRangeChange` 同时传入即开启虚拟滚动 |
 | loadingIndexes | Set \| array | - | 异步分页：正在加载的下标，显示骨架占位 |
-| onVisibleRangeChange | function(range) | - | 异步分页：可视范围变化；`range` 含 `startIndex` / `endIndex` / `view` / `viewport` / `pageSize` / `currentPath` / `keyword` |
+| ready | boolean | - | 异步分页：当前目录是否已确认首屏数据；`false` 时即使 `totalCount === 0` 仍挂载虚拟列表以测量视口；未传时保持旧逻辑 |
+| columnListings | object | - | 异步分页（分栏）：按目录 path 隔离的列表数据，形如 `{ [path]: { entries, totalCount, loadingIndexes?, ready? } }`；展开列从这里读，避免只靠当前目录 `entries` |
+| onRegisterFolder | function(path, id) | - | 分栏单击文件夹展开下一列时回调；用于业务侧登记 folderId 与 path 的映射 |
+| onVisibleRangeChange | function(range) | - | 异步分页：可视范围变化。`range` 含：`startIndex` / `endIndex` / `view` / `viewport` / `pageSize` / `currentPath` / `keyword` / `path` / `columnPath`。分栏展开列以 `columnPath`（或合并后的 `path`）为准拉目录；其它视图 `path` 等于 `currentPath` |
 
-`FileSystem.calcPageSize({ view, width, height })` 可按视口估算建议 `perPage`。
+`calcPageSize({ view, width, height, buffer? })` 可按视口估算建议 `perPage`（也可写作 `FileSystem.calcPageSize`）。`view` 为 `icons` / `list` / `columns` / `gallery`；`buffer` 默认 `2`，结果夹在 20–200。
 
 #### FileSystem.PropertiesPanel
 
@@ -415,6 +420,50 @@ const MyComponent = withOSSFile(({ data, id, ...props }) => {
 
 ---
 
+### uploadFile
+
+统一上传入口。库内上传应走此 API；会解析自定义 `onUpload` 或 preset `apis.file.upload` / `ossUpload` / `upload`，并将 `directory` 映射为后端 `path`。
+
+#### 参数
+
+| 参数 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| file | File | - | 待上传文件 |
+| directory | string | - | 上传目录，映射为请求体 `path` |
+| onUpload | function({ file, path? }) | - | 自定义上传函数；不传则读 `apis` |
+| apis | object | - | API 配置；默认取自 preset |
+
+#### 返回值
+
+上传接口的原始返回值（通常为 `{ data: { code, data, msg } }` 形态，由业务 `apis.file.upload` 决定）。
+
+```jsx
+import { uploadFile } from '@kne/react-file';
+
+await uploadFile({ file, directory: 'docs/2026' });
+```
+
+---
+
+### useUploadFile
+
+返回绑定当前 preset `apis` 的 `uploadFile` 函数，便于在组件内直接调用。
+
+#### 返回值
+
+| 类型 | 描述 |
+|------|------|
+| function(params) | 同 `uploadFile`；可再传 `apis` 覆盖 preset |
+
+```jsx
+import { useUploadFile } from '@kne/react-file';
+
+const upload = useUploadFile();
+await upload({ file, directory: 'avatars' });
+```
+
+---
+
 ### useFileUpload
 
 文件上传Hook，处理文件上传逻辑。
@@ -432,7 +481,8 @@ const MyComponent = withOSSFile(({ data, id, ...props }) => {
 | onError | function({ file, error, errMsg }) | - | 上传失败回调 |
 | onSave | function(data, file, uuid) | - | 上传成功后数据处理回调 |
 | onChange | function(list) | - | 文件列表变化回调 |
-| onUpload | function({ file }) | - | 自定义上传函数 |
+| onUpload | function({ file, path? }) | - | 自定义上传函数 |
+| directory | string | - | 上传目录；内部映射为后端 `path` |
 
 #### 返回值
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/react-file",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "description": "React文件操作组件库，提供文件上传、多格式预览、下载、列表管理及文件系统浏览，支持i18n",
   "syntax": {
     "esmodules": true

--- a/src/components/FileSystem/VirtualViews.js
+++ b/src/components/FileSystem/VirtualViews.js
@@ -189,9 +189,35 @@ const EntrySkeleton = ({ variant = 'icons' }) => {
   );
 };
 
+const toLoadingSet = loadingIndexes => {
+  if (loadingIndexes instanceof Set) {
+    return loadingIndexes;
+  }
+  if (Array.isArray(loadingIndexes) || loadingIndexes instanceof Map) {
+    return new Set(loadingIndexes);
+  }
+  return new Set();
+};
+
+/** 仅在真正请求中的下标显示骨架；total=0 时用 loading 下标撑起首屏占位 */
+const resolveVirtualCount = (totalCount, entries, loadingSet) => {
+  const base = totalCount != null ? totalCount : entries?.length || 0;
+  if (!loadingSet.size) {
+    return Math.max(0, base);
+  }
+  let loadingMax = 0;
+  loadingSet.forEach(index => {
+    if (index + 1 > loadingMax) {
+      loadingMax = index + 1;
+    }
+  });
+  return Math.max(0, base, loadingMax);
+};
+
 export const IconsView = ({ entries, totalCount, selectedPaths, onSelect, onOpen, resolveStatus, loadingIndexes, onVisibleRangeChange, requestKey = '' }) => {
   const parentRef = useRef(null);
-  const count = totalCount != null ? totalCount : entries.length;
+  const loadingSet = toLoadingSet(loadingIndexes);
+  const count = resolveVirtualCount(totalCount, entries, loadingSet);
   const viewport = useElementSize(parentRef);
   const measured = viewport.width > 0 && viewport.height > 0;
   const cols = Math.max(1, Math.floor((Math.max(viewport.width || 400, ICONS_CELL_WIDTH) - ICONS_PADDING_X) / ICONS_CELL_WIDTH));
@@ -269,8 +295,10 @@ export const IconsView = ({ entries, totalCount, selectedPaths, onSelect, onOpen
                       {entry.name}
                     </span>
                   </div>
-                ) : (
+                ) : loadingSet.has(index) ? (
                   <EntrySkeleton key={`sk-${index}`} />
+                ) : (
+                  <div key={`empty-${index}`} className={style['icon-item']} aria-hidden />
                 )
               );
             }
@@ -301,7 +329,8 @@ export const IconsView = ({ entries, totalCount, selectedPaths, onSelect, onOpen
 
 export const ListTableView = ({ columns, entries, totalCount, selectedPaths, onSelect, onOpen, resolveStatus, loadingIndexes, onVisibleRangeChange, requestKey = '' }) => {
   const parentRef = useRef(null);
-  const count = totalCount != null ? totalCount : entries.length;
+  const loadingSet = toLoadingSet(loadingIndexes);
+  const count = resolveVirtualCount(totalCount, entries, loadingSet);
   const viewport = useElementSize(parentRef);
   const measured = viewport.width > 0 && viewport.height > 0;
   const pageSize = calcPageSize({
@@ -425,9 +454,9 @@ export const ListTableView = ({ columns, entries, totalCount, selectedPaths, onS
                     {entry.name}
                   </span>
                 </>
-              ) : (
+              ) : loadingSet.has(index) ? (
                 <EntrySkeleton variant="inline" />
-              )}
+              ) : null}
             </div>
           );
         })}
@@ -523,6 +552,7 @@ export const ColumnsView = ({
 
 const ColumnPane = ({ columnPath, columnIndex, entries, count, selectedPaths, onSelect, onOpen, onNavigateColumn, resolveStatus, isMobile, lastTapRef, loadingIndexes, onVisibleRangeChange, emitRange, requestKey = '' }) => {
   const parentRef = useRef(null);
+  const loadingSet = toLoadingSet(loadingIndexes);
   const viewport = useElementSize(parentRef);
   const measured = viewport.width > 0 && viewport.height > 0;
   const pageSize = calcPageSize({
@@ -532,7 +562,7 @@ const ColumnPane = ({ columnPath, columnIndex, entries, count, selectedPaths, on
   });
 
   const rowVirtualizer = useVirtualizer({
-    count: Math.max(0, count),
+    count: Math.max(0, resolveVirtualCount(count, entries, loadingSet)),
     getScrollElement: () => parentRef.current,
     estimateSize: () => COLUMN_ITEM_HEIGHT,
     overscan: 8
@@ -633,9 +663,9 @@ const ColumnPane = ({ columnPath, columnIndex, entries, count, selectedPaths, on
                   </span>
                   {entry.kind === 'file' ? <span className={style['column-meta']}>{formatByteSize(entry.size)}</span> : null}
                 </>
-              ) : (
+              ) : loadingSet.has(virtualRow.index) ? (
                 <EntrySkeleton variant="inline" />
-              )}
+              ) : null}
             </div>
           );
         })}
@@ -646,7 +676,8 @@ const ColumnPane = ({ columnPath, columnIndex, entries, count, selectedPaths, on
 
 export const GalleryView = ({ entries, totalCount, selectedPaths, onSelect, onOpen, renderFilePreview, canPreviewFile, formatMessage, resolveStatus, loadingIndexes, onVisibleRangeChange, requestKey = '' }) => {
   const filmstripRef = useRef(null);
-  const count = totalCount != null ? totalCount : entries.length;
+  const loadingSet = toLoadingSet(loadingIndexes);
+  const count = resolveVirtualCount(totalCount, entries, loadingSet);
   const viewport = useElementSize(filmstripRef);
   const measured = viewport.width > 0 && viewport.height > 0;
   const pageSize = calcPageSize({
@@ -795,9 +826,9 @@ export const GalleryView = ({ entries, totalCount, selectedPaths, onSelect, onOp
                         {entry.name}
                       </span>
                     </>
-                  ) : (
+                  ) : loadingSet.has(virtualRow.index) ? (
                     <EntrySkeleton variant="inline" />
-                  )}
+                  ) : null}
                 </div>
               );
             })}


### PR DESCRIPTION
避免 totalCount 虚高时空洞被当成永久 loading；同步补充 directory/uploadFile 等 API 说明。