### PR TITLE
fix: withLocale 挂载中英文词条，修复 en-US 缺译

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/react-file",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "description": "React文件操作组件库，提供文件上传、多格式预览、下载、列表管理及文件系统浏览，支持i18n",
   "syntax": {
     "esmodules": true

--- a/src/withLocale.js
+++ b/src/withLocale.js
@@ -1,8 +1,14 @@
 import { createWithIntlProvider } from '@kne/react-intl';
-import zhCn from './locale/zh-CN';
+import zhCN from './locale/zh-CN';
+import enUS from './locale/en-US';
 
-const withLocale = WrappedComponent => {
-  return createWithIntlProvider('zh-CN', zhCn, 'react-file')(WrappedComponent);
-};
+const withLocale = createWithIntlProvider({
+  defaultLocale: 'zh-CN',
+  messages: {
+    'zh-CN': zhCN,
+    'en-US': enUS
+  },
+  namespace: 'react-file'
+});
 
 export default withLocale;


### PR DESCRIPTION
## Summary
- `withLocale` 改为 `createWithIntlProvider` 标准写法，同时注册 `zh-CN` / `en-US`。
- 修复英文环境下 `FileUpload.fileUpload` 等 key 的 MISSING_TRANSLATION。
- 版本：`0.1.56` → `0.1.57`

## Test plan
- [ ] 中文下上传/预览等文案正常
- [ ] 英文下不再出现 `FileUpload.fileUpload` 的 MISSING_TRANSLATION
- [ ] 英文下上传按钮等显示 en-US 词条（如 Upload file）

Made with [Cursor](https://cursor.com)