### PR TITLE
fix: 列表空白 hover 与上传到当前文件夹

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,27 +1136,25 @@ render(<BaseExample />);
 ```
 
 - FileSystem 扩展顶部菜单
-- 通过 toolbarExtra 在导航栏追加上传、新建文件夹、刷新、删除选中等自定义操作
+- 通过 toolbarExtra 在导航栏追加上传、新建文件夹、刷新、删除选中等自定义操作；上传请使用 FileUpload（在 FileSystem 内会自动带上当前 uploadPath）
 - _ReactFile(@kne/current-lib_react-file)[import * as _ReactFile from "@kne/react-file"],(@kne/current-lib_react-file/dist/index.css),antd(antd),icons(@ant-design/icons),remoteLoader(@kne/remote-loader)
 
 ```jsx
-const { FileSystem } = _ReactFile;
+const { FileSystem, FileUpload } = _ReactFile;
 const { createWithRemoteLoader, getPublicPath } = remoteLoader;
 const { Button, message, Space } = antd;
-const { DeleteOutlined, ReloadOutlined, UploadOutlined, FolderAddOutlined } = icons;
-const { useState } = React;
+const { DeleteOutlined, ReloadOutlined, FolderAddOutlined } = icons;
 
 const BaseExample = createWithRemoteLoader({
   modules: ['components-core:Global@PureGlobal', 'components-core:InfoPage']
 })(({ remoteModules }) => {
   const [PureGlobal, InfoPage] = remoteModules;
-  const [selectedEntries, setSelectedEntries] = useState([]);
-  const [items] = useState([
+  const items = [
     { kind: 'folder', path: 'documents/', name: 'Documents' },
     { kind: 'file', path: 'documents/Q3-report.pdf', name: 'Q3-report.pdf', size: 1024000 },
     { kind: 'file', path: 'documents/notes.md', name: 'notes.md', size: 3200 },
     { kind: 'file', path: 'readme.txt', name: 'readme.txt', size: 1200 }
-  ]);
+  ];
 
   return (
     <PureGlobal
@@ -1164,7 +1162,16 @@ const BaseExample = createWithRemoteLoader({
         ajax: async api => ({ data: { code: 0, data: api.loader?.() } }),
         apis: {
           file: {
-            staticUrl: getPublicPath('react-file') || window.PUBLIC_URL
+            staticUrl: getPublicPath('react-file') || window.PUBLIC_URL,
+            upload: async ({ file, path }) => {
+              console.log('upload to', path || '(root)', file?.name);
+              return {
+                data: {
+                  code: 0,
+                  data: { id: `mock-${Date.now()}`, filename: file.name, path: path || '' }
+                }
+              };
+            }
           }
         }
       }}
@@ -1175,19 +1182,15 @@ const BaseExample = createWithRemoteLoader({
             items={items}
             title="My Files"
             defaultView="list"
-            toolbarExtra={
+            toolbarExtra={({ uploadPath, selectedEntries, clearSelection }) => (
               <Space size={8}>
-                <Button size="small" icon={<UploadOutlined />} onClick={() => message.info('自定义上传')}>
+                <FileUpload showUploadList={false} size="small">
                   上传
-                </Button>
-                <Button size="small" icon={<FolderAddOutlined />} onClick={() => message.info('自定义新建文件夹')}>
+                </FileUpload>
+                <Button size="small" icon={<FolderAddOutlined />} onClick={() => message.info(`新建文件夹于 ${uploadPath || '/'}`)}>
                   新建文件夹
                 </Button>
-                <Button
-                  size="small"
-                  icon={<ReloadOutlined />}
-                  onClick={() => message.success('已刷新')}
-                >
+                <Button size="small" icon={<ReloadOutlined />} onClick={() => message.success('已刷新')}>
                   刷新
                 </Button>
                 <Button
@@ -1195,15 +1198,15 @@ const BaseExample = createWithRemoteLoader({
                   danger
                   icon={<DeleteOutlined />}
                   disabled={!selectedEntries.length}
-                  onClick={() => message.info(&#96;已选择 ${selectedEntries.length} 项&#96;)}
+                  onClick={() => {
+                    message.info(`已选择 ${selectedEntries.length} 项`);
+                    clearSelection();
+                  }}
                 >
                   删除选中
                 </Button>
               </Space>
-            }
-            onSelectionChange={entries => {
-              setSelectedEntries(entries || []);
-            }}
+            )}
             onFileOpen={entry => {
               console.log('Open file:', entry);
             }}
@@ -1514,7 +1517,7 @@ render(<BaseExample />);
 | onSave | function(data, file, uuid) | - | 上传成功后数据处理回调，返回值将作为新的文件对象 |
 | onUpload | function({ file, path? }) | - | 自定义上传函数；优先于 `ossUpload` / preset `apis.file.upload` |
 | ossUpload | function | - | 自定义上传函数（兼容旧写法，等价于 `onUpload`） |
-| directory | string | - | 上传目录；内部映射为后端 `path` 传给上传接口 |
+| directory | string | - | 上传目录；内部映射为后端 `path`。在 `FileSystem` 内未传时自动使用当前 `uploadPath` |
 | getPermission | function(type) | - | 文件列表操作权限控制函数，type为'preview'/'delete'等 |
 | apis | object | - | API配置对象 |
 | renderModal | function(modalProps) | props => Modal | 自定义弹窗渲染函数 |
@@ -1796,7 +1799,7 @@ ZIP压缩包文件预览组件，支持查看压缩包内部的文件列表和�
 | defaultView | 'icons' \| 'list' \| 'columns' \| 'gallery' | 'list' | 默认视图模式 |
 | defaultPath | string | '' | 默认路径 |
 | className | string | - | 自定义类名 |
-| toolbarExtra | ReactNode \| (ctx) => ReactNode | - | 工具栏扩展；函数时接收 `{ selectedEntries, clearSelection, currentPath }` |
+| toolbarExtra | ReactNode \| (ctx) => ReactNode | - | 工具栏扩展；函数时接收 `{ selectedEntries, clearSelection, currentPath, uploadPath }`。`uploadPath` 为实际上传目录；在 `FileSystem` 内使用 `FileUpload` / `useUploadFile` 且未传 `directory` 时自动使用 |
 | propertiesPanel | boolean \| ReactNode \| (ctx) => ReactNode | true | 右侧属性面板；`false` 关闭；函数时接收 `{ selectedEntries, index, currentPath, close, actions, onAction, defaultActions }` |
 | propertiesActions | false \| ActionItem[] \| (ctx) => ActionItem[] \| object | 内置默认 | 属性面板操作；`false` 关闭；数组按 key 合并；函数完全自定义；`{ list, replace?, ...ButtonGroupProps }` 可替换或合并 |
 | onPropertiesAction | (key, ctx) => void | - | 操作点击回调；`ctx` 含 `entry` / `selectedEntries` / `clearSelection` / `currentPath` |

--- a/doc/api.md
+++ b/doc/api.md
@@ -39,7 +39,7 @@
 | onSave | function(data, file, uuid) | - | 上传成功后数据处理回调，返回值将作为新的文件对象 |
 | onUpload | function({ file, path? }) | - | 自定义上传函数；优先于 `ossUpload` / preset `apis.file.upload` |
 | ossUpload | function | - | 自定义上传函数（兼容旧写法，等价于 `onUpload`） |
-| directory | string | - | 上传目录；内部映射为后端 `path` 传给上传接口 |
+| directory | string | - | 上传目录；内部映射为后端 `path` 传给上传接口。在 `FileSystem` 内未传时自动使用当前 `uploadPath` |
 | getPermission | function(type) | - | 文件列表操作权限控制函数，type为'preview'/'delete'等 |
 | apis | object | - | API配置对象 |
 | renderModal | function(modalProps) | props => Modal | 自定义弹窗渲染函数 |
@@ -321,7 +321,7 @@ ZIP压缩包文件预览组件，支持查看压缩包内部的文件列表和�
 | defaultView | 'icons' \| 'list' \| 'columns' \| 'gallery' | 'list' | 默认视图模式 |
 | defaultPath | string | '' | 默认路径 |
 | className | string | - | 自定义类名 |
-| toolbarExtra | ReactNode \| (ctx) => ReactNode | - | 工具栏扩展；函数时接收 `{ selectedEntries, clearSelection, currentPath }` |
+| toolbarExtra | ReactNode \| (ctx) => ReactNode | - | 工具栏扩展；函数时接收 `{ selectedEntries, clearSelection, currentPath, uploadPath }`。`uploadPath` 为实际上传目录（进入的目录；分栏下为正在浏览的最深文件夹）。在 `FileSystem` 内使用 `FileUpload` / `useUploadFile` 且未传 `directory` 时，会自动使用 `uploadPath` |
 | propertiesPanel | boolean \| ReactNode \| (ctx) => ReactNode | true | 右侧属性面板；`false` 关闭；函数时接收 `{ selectedEntries, index, currentPath, close, actions, onAction, defaultActions }` |
 | propertiesActions | false \| ActionItem[] \| (ctx) => ActionItem[] \| object | 内置默认 | 属性面板操作；`false` 关闭；数组按 key 合并；函数完全自定义；`{ list, replace?, ...ButtonGroupProps }` 可替换或合并 |
 | onPropertiesAction | (key, ctx) => void | - | 操作点击回调；`ctx` 含 `entry` / `selectedEntries` / `clearSelection` / `currentPath` |
@@ -429,7 +429,8 @@ const MyComponent = withOSSFile(({ data, id, ...props }) => {
 | 参数 | 类型 | 默认值 | 描述 |
 |------|------|--------|------|
 | file | File | - | 待上传文件 |
-| directory | string | - | 上传目录，映射为请求体 `path` |
+| directory | string | - | 上传目录，映射为请求体 `path`；也可直接传 `path`（同义） |
+| path | string | - | 同 `directory`（兼容后端字段名；勿只传 `path` 却期望被忽略） |
 | onUpload | function({ file, path? }) | - | 自定义上传函数；不传则读 `apis` |
 | apis | object | - | API 配置；默认取自 preset |
 

--- a/doc/example.json
+++ b/doc/example.json
@@ -259,7 +259,7 @@
     },
     {
       "title": "FileSystem 扩展顶部菜单",
-      "description": "通过 toolbarExtra 在导航栏追加上传、新建文件夹、刷新、删除选中等自定义操作",
+      "description": "通过 toolbarExtra 在导航栏追加上传、新建文件夹、刷新、删除选中等自定义操作；FileUpload 会自动上传到当前 uploadPath",
       "code": "./file-system-toolbar-extra.js",
       "scope": [
         {

--- a/doc/file-system-toolbar-extra.js
+++ b/doc/file-system-toolbar-extra.js
@@ -1,20 +1,18 @@
-const { FileSystem } = _ReactFile;
+const { FileSystem, FileUpload } = _ReactFile;
 const { createWithRemoteLoader, getPublicPath } = remoteLoader;
 const { Button, message, Space } = antd;
-const { DeleteOutlined, ReloadOutlined, UploadOutlined, FolderAddOutlined } = icons;
-const { useState } = React;
+const { DeleteOutlined, ReloadOutlined, FolderAddOutlined } = icons;
 
 const BaseExample = createWithRemoteLoader({
   modules: ['components-core:Global@PureGlobal', 'components-core:InfoPage']
 })(({ remoteModules }) => {
   const [PureGlobal, InfoPage] = remoteModules;
-  const [selectedEntries, setSelectedEntries] = useState([]);
-  const [items] = useState([
+  const items = [
     { kind: 'folder', path: 'documents/', name: 'Documents' },
     { kind: 'file', path: 'documents/Q3-report.pdf', name: 'Q3-report.pdf', size: 1024000 },
     { kind: 'file', path: 'documents/notes.md', name: 'notes.md', size: 3200 },
     { kind: 'file', path: 'readme.txt', name: 'readme.txt', size: 1200 }
-  ]);
+  ];
 
   return (
     <PureGlobal
@@ -22,7 +20,17 @@ const BaseExample = createWithRemoteLoader({
         ajax: async api => ({ data: { code: 0, data: api.loader?.() } }),
         apis: {
           file: {
-            staticUrl: getPublicPath('react-file') || window.PUBLIC_URL
+            staticUrl: getPublicPath('react-file') || window.PUBLIC_URL,
+            upload: async ({ file, path }) => {
+              // path 为当前文件夹（进入目录或分栏展开后的 uploadPath）
+              console.log('upload to', path || '(root)', file?.name);
+              return {
+                data: {
+                  code: 0,
+                  data: { id: `mock-${Date.now()}`, filename: file.name, path: path || '' }
+                }
+              };
+            }
           }
         }
       }}
@@ -33,19 +41,16 @@ const BaseExample = createWithRemoteLoader({
             items={items}
             title="My Files"
             defaultView="list"
-            toolbarExtra={
+            toolbarExtra={({ uploadPath, selectedEntries, clearSelection }) => (
               <Space size={8}>
-                <Button size="small" icon={<UploadOutlined />} onClick={() => message.info('自定义上传')}>
+                {/* 在 FileSystem 内未传 directory 时，FileUpload 会自动使用当前 uploadPath */}
+                <FileUpload showUploadList={false} size="small">
                   上传
-                </Button>
-                <Button size="small" icon={<FolderAddOutlined />} onClick={() => message.info('自定义新建文件夹')}>
+                </FileUpload>
+                <Button size="small" icon={<FolderAddOutlined />} onClick={() => message.info(`新建文件夹于 ${uploadPath || '/'}`)}>
                   新建文件夹
                 </Button>
-                <Button
-                  size="small"
-                  icon={<ReloadOutlined />}
-                  onClick={() => message.success('已刷新')}
-                >
+                <Button size="small" icon={<ReloadOutlined />} onClick={() => message.success('已刷新')}>
                   刷新
                 </Button>
                 <Button
@@ -53,15 +58,15 @@ const BaseExample = createWithRemoteLoader({
                   danger
                   icon={<DeleteOutlined />}
                   disabled={!selectedEntries.length}
-                  onClick={() => message.info(`已选择 ${selectedEntries.length} 项`)}
+                  onClick={() => {
+                    message.info(`已选择 ${selectedEntries.length} 项`);
+                    clearSelection();
+                  }}
                 >
                   删除选中
                 </Button>
               </Space>
-            }
-            onSelectionChange={entries => {
-              setSelectedEntries(entries || []);
-            }}
+            )}
             onFileOpen={entry => {
               console.log('Open file:', entry);
             }}

--- a/src/components/FileSystem/FileSystem.js
+++ b/src/components/FileSystem/FileSystem.js
@@ -7,6 +7,7 @@ import style from './FileSystem.module.scss';
 import EntryIcon from './EntryIcon';
 import PropertiesPanel from './PropertiesPanel';
 import MarqueeSelect from './MarqueeSelect';
+import FileSystemContext from './FileSystemContext';
 import { IconsView as VirtualIconsView, ListTableView as VirtualListTableView, ColumnsView as VirtualColumnsView, GalleryView as VirtualGalleryView } from './VirtualViews';
 import { buildFileSystemIndex, buildNestedEntries, formatByteSize, normalizeFolderPath, normalizeSearchQuery, pathName, pathParent } from './utils';
 import { calcPageSize } from './calcPageSize';
@@ -422,6 +423,17 @@ const FileSystemInner = ({
   const currentFolderName = currentPath === '' ? title : pathName(currentPath) || title;
   const canGoUp = !!currentPath;
 
+  // 分栏单击展开时 currentPath 仍是导航路径；上传应落到正在浏览的最深目录
+  const uploadPath = view === 'columns' && columnSelection.length > 0 ? columnSelection[columnSelection.length - 1] : currentPath;
+
+  const fileSystemContextValue = useMemo(
+    () => ({
+      currentPath,
+      uploadPath
+    }),
+    [currentPath, uploadPath]
+  );
+
   const viewOptions = useMemo(
     () => [
       { label: formatMessage({ id: 'FileSystem.viewGrid' }), value: 'icons', icon: <AppstoreOutlined /> },
@@ -641,43 +653,45 @@ const FileSystemInner = ({
   const marqueeEnabled = !isMobile && (view === 'icons' || (view === 'list' && (isSearching || isAsyncMode)));
 
   return (
-    <div className={classnames(style.root, className)}>
-      <div className={style.toolbar}>
-        <Input allowClear size="small" className={style['search-input']} placeholder={formatMessage({ id: 'FileSystem.search' })} prefix={<SearchOutlined />} value={searchInput} onChange={event => setSearchInput(event.target.value)} />
-        <div className={style['toolbar-nav']}>
-          <Button type="text" size="small" icon={<ArrowLeftOutlined />} disabled={!canGoUp} onClick={goUp} title={formatMessage({ id: 'FileSystem.goUp' })} />
+    <FileSystemContext.Provider value={fileSystemContextValue}>
+      <div className={classnames(style.root, className)}>
+        <div className={style.toolbar}>
+          <Input allowClear size="small" className={style['search-input']} placeholder={formatMessage({ id: 'FileSystem.search' })} prefix={<SearchOutlined />} value={searchInput} onChange={event => setSearchInput(event.target.value)} />
+          <div className={style['toolbar-nav']}>
+            <Button type="text" size="small" icon={<ArrowLeftOutlined />} disabled={!canGoUp} onClick={goUp} title={formatMessage({ id: 'FileSystem.goUp' })} />
+          </div>
+          <div className={style['toolbar-title']} title={currentFolderName}>
+            {currentFolderName}
+          </div>
+          {toolbarExtra ? <div className={style['toolbar-extra']}>{typeof toolbarExtra === 'function' ? toolbarExtra({ selectedEntries, clearSelection, currentPath, uploadPath }) : toolbarExtra}</div> : null}
+          <Segmented size="small" className={style['view-switch']} value={view} onChange={setView} options={segmentedOptions} />
         </div>
-        <div className={style['toolbar-title']} title={currentFolderName}>
-          {currentFolderName}
+        <div className={style.main}>
+          <div className={style.content}>
+            <MarqueeSelect enabled={marqueeEnabled} className={isAsyncMode || view === 'gallery' || view === 'columns' ? style['marquee-fill'] : undefined} onMarqueeSelect={handleMarqueeSelect} onEmptyClick={handleEmptyClick}>
+              {renderContent()}
+            </MarqueeSelect>
+          </div>
+          {showPropertiesPanel ? (
+            <PropertiesPanel
+              selectedEntries={selectedEntries}
+              index={index}
+              currentPath={currentPath}
+              propertiesPanel={propertiesPanel}
+              propertiesActions={propertiesActions}
+              onPropertiesAction={handlePropertiesAction}
+              onClose={() => setPropertiesPanelClosed(true)}
+            />
+          ) : null}
         </div>
-        {toolbarExtra ? <div className={style['toolbar-extra']}>{typeof toolbarExtra === 'function' ? toolbarExtra({ selectedEntries, clearSelection, currentPath }) : toolbarExtra}</div> : null}
-        <Segmented size="small" className={style['view-switch']} value={view} onChange={setView} options={segmentedOptions} />
-      </div>
-      <div className={style.main}>
-        <div className={style.content}>
-          <MarqueeSelect enabled={marqueeEnabled} className={isAsyncMode || view === 'gallery' || view === 'columns' ? style['marquee-fill'] : undefined} onMarqueeSelect={handleMarqueeSelect} onEmptyClick={handleEmptyClick}>
-            {renderContent()}
-          </MarqueeSelect>
+        <div className={style.footer}>
+          <span>
+            {displayCount} {isSearching ? formatMessage({ id: 'FileSystem.resultCount' }) : formatMessage({ id: 'FileSystem.itemCount' })}
+          </span>
+          {footerSelection}
         </div>
-        {showPropertiesPanel ? (
-          <PropertiesPanel
-            selectedEntries={selectedEntries}
-            index={index}
-            currentPath={currentPath}
-            propertiesPanel={propertiesPanel}
-            propertiesActions={propertiesActions}
-            onPropertiesAction={handlePropertiesAction}
-            onClose={() => setPropertiesPanelClosed(true)}
-          />
-        ) : null}
       </div>
-      <div className={style.footer}>
-        <span>
-          {displayCount} {isSearching ? formatMessage({ id: 'FileSystem.resultCount' }) : formatMessage({ id: 'FileSystem.itemCount' })}
-        </span>
-        {footerSelection}
-      </div>
-    </div>
+    </FileSystemContext.Provider>
   );
 };
 

--- a/src/components/FileSystem/FileSystem.module.scss
+++ b/src/components/FileSystem/FileSystem.module.scss
@@ -472,8 +472,13 @@
   user-select: none;
   touch-action: manipulation;
 
-  &:hover {
+  // 仅真实条目可悬停；空白占位/骨架不应露出「单元格」高亮
+  &:not(.is-placeholder):hover {
     background: rgba(0, 0, 0, 0.04);
+  }
+
+  &.is-placeholder {
+    pointer-events: none;
   }
 
   &.selected {
@@ -547,8 +552,12 @@
   cursor: default;
   user-select: none;
 
-  &:hover {
+  &:not(.is-placeholder):hover {
     background: rgba(0, 0, 0, 0.04);
+  }
+
+  &.is-placeholder {
+    pointer-events: none;
   }
 
   &.selected {
@@ -583,8 +592,14 @@
   touch-action: manipulation;
   text-align: center;
 
-  &:hover {
+  &:not(.is-placeholder):hover {
     background: rgba(0, 0, 0, 0.04);
+  }
+
+  &.is-placeholder {
+    pointer-events: none;
+    border-color: transparent;
+    background: transparent;
   }
 
   &.selected {
@@ -815,8 +830,12 @@
     top: -1px;
   }
 
-  &:hover {
+  &:not(.is-placeholder):hover {
     background: rgba(0, 0, 0, 0.04);
+  }
+
+  &.is-placeholder {
+    pointer-events: none;
   }
 
   &.selected {
@@ -968,8 +987,12 @@
   user-select: none;
   touch-action: manipulation;
 
-  &:hover {
+  &:not(.is-placeholder):hover {
     background: rgba(0, 0, 0, 0.04);
+  }
+
+  &.is-placeholder {
+    pointer-events: none;
   }
 
   &.selected {

--- a/src/components/FileSystem/FileSystemContext.js
+++ b/src/components/FileSystem/FileSystemContext.js
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+const FileSystemContext = createContext(null);
+
+export const useFileSystemContext = () => useContext(FileSystemContext);
+
+export default FileSystemContext;

--- a/src/components/FileSystem/VirtualViews.js
+++ b/src/components/FileSystem/VirtualViews.js
@@ -182,7 +182,7 @@ const EntrySkeleton = ({ variant = 'icons' }) => {
   }
 
   return (
-    <div className={classnames(style['icon-item'], style['entry-skeleton-icons'])}>
+    <div className={classnames(style['icon-item'], style['entry-skeleton-icons'], style['is-placeholder'])}>
       <span className={style['entry-skeleton-icon']} />
       <span className={style['entry-skeleton-name']} />
     </div>
@@ -298,7 +298,7 @@ export const IconsView = ({ entries, totalCount, selectedPaths, onSelect, onOpen
                 ) : loadingSet.has(index) ? (
                   <EntrySkeleton key={`sk-${index}`} />
                 ) : (
-                  <div key={`empty-${index}`} className={style['icon-item']} aria-hidden />
+                  <div key={`empty-${index}`} className={classnames(style['icon-item'], style['is-placeholder'])} aria-hidden />
                 )
               );
             }
@@ -422,7 +422,7 @@ export const ListTableView = ({ columns, entries, totalCount, selectedPaths, onS
           return (
             <div
               key={virtualRow.key}
-              className={classnames(style['list-tree-row'], entry && selectedPaths.includes(entry.path) && style.selected)}
+              className={classnames(style['list-tree-row'], !entry && style['is-placeholder'], entry && selectedPaths.includes(entry.path) && style.selected)}
               data-fs-path={entry?.path}
               data-fs-index={index}
               style={{
@@ -615,7 +615,7 @@ const ColumnPane = ({ columnPath, columnIndex, entries, count, selectedPaths, on
               key={virtualRow.key}
               data-fs-path={entry?.path}
               data-fs-index={virtualRow.index}
-              className={classnames(style['column-item'], entry && selectedPaths.includes(entry.path) && style.selected)}
+              className={classnames(style['column-item'], !entry && style['is-placeholder'], entry && selectedPaths.includes(entry.path) && style.selected)}
               style={{
                 position: 'absolute',
                 top: 0,
@@ -807,7 +807,7 @@ export const GalleryView = ({ entries, totalCount, selectedPaths, onSelect, onOp
                   key={virtualRow.key}
                   data-fs-path={entry?.path}
                   data-fs-index={virtualRow.index}
-                  className={classnames(style['gallery-film-item'], entry && entry.path === activePath && style.selected)}
+                  className={classnames(style['gallery-film-item'], !entry && style['is-placeholder'], entry && entry.path === activePath && style.selected)}
                   style={{
                     position: 'absolute',
                     top: 0,

--- a/src/components/FileSystem/index.js
+++ b/src/components/FileSystem/index.js
@@ -1,5 +1,6 @@
 export { default, FileSystemInner, PropertiesPanel, calcPageSize } from './FileSystem';
 export { default as EntryIcon } from './EntryIcon';
+export { useFileSystemContext } from './FileSystemContext';
 export {
   Default as PropertiesPanelDefault,
   InfoRow as PropertiesPanelInfoRow,

--- a/src/components/FileUpload/__tests__/uploadFile.test.js
+++ b/src/components/FileUpload/__tests__/uploadFile.test.js
@@ -1,0 +1,27 @@
+import { uploadFile } from '../uploadFile';
+
+describe('uploadFile', () => {
+  it('maps directory to path', async () => {
+    const onUpload = jest.fn(async payload => ({ data: { code: 0, data: payload } }));
+    await uploadFile({ file: { name: 'a.txt' }, directory: 'docs/', onUpload });
+    expect(onUpload).toHaveBeenCalledWith({ file: { name: 'a.txt' }, path: 'docs/' });
+  });
+
+  it('accepts path alias so uploads do not fall back to root', async () => {
+    const onUpload = jest.fn(async payload => ({ data: { code: 0, data: payload } }));
+    await uploadFile({ file: { name: 'a.txt' }, path: 'documents/', onUpload });
+    expect(onUpload).toHaveBeenCalledWith({ file: { name: 'a.txt' }, path: 'documents/' });
+  });
+
+  it('prefers directory over path when both are provided', async () => {
+    const onUpload = jest.fn(async payload => ({ data: { code: 0, data: payload } }));
+    await uploadFile({ file: { name: 'a.txt' }, directory: 'a/', path: 'b/', onUpload });
+    expect(onUpload).toHaveBeenCalledWith({ file: { name: 'a.txt' }, path: 'a/' });
+  });
+
+  it('omits path for root/empty directory', async () => {
+    const onUpload = jest.fn(async payload => ({ data: { code: 0, data: payload } }));
+    await uploadFile({ file: { name: 'a.txt' }, directory: '', onUpload });
+    expect(onUpload).toHaveBeenCalledWith({ file: { name: 'a.txt' } });
+  });
+});

--- a/src/components/FileUpload/uploadFile.js
+++ b/src/components/FileUpload/uploadFile.js
@@ -1,22 +1,33 @@
 import { usePreset } from '@kne/global-context';
 import useRefCallback from '@kne/use-ref-callback';
+import { useFileSystemContext } from '../FileSystem/FileSystemContext';
 
 /**
  * 统一上传入口：解析 preset / 自定义 onUpload，并将 directory 映射为后端 path。
  * 库内上传应只走此 API，禁止直接调用 apis.file.upload / ossUpload。
+ * 兼容直接传 path（与后端字段同名），避免误传 path 被忽略而落到根目录。
  */
-export const uploadFile = async ({ file, directory, onUpload, apis } = {}) => {
+export const uploadFile = async ({ file, directory, path, onUpload, apis } = {}) => {
   const uploadFun = onUpload || apis?.file?.upload || apis?.ossUpload || apis?.upload;
   if (typeof uploadFun !== 'function') {
     throw new Error('未配置上传接口，请在 preset apis 中设置 file.upload');
   }
-  const payload = Object.assign({}, { file }, directory ? { path: directory } : {});
+  const uploadDirectory = directory !== undefined && directory !== null ? directory : path;
+  const payload = Object.assign({}, { file }, uploadDirectory ? { path: uploadDirectory } : {});
   return uploadFun(payload);
 };
 
 export const useUploadFile = () => {
   const { apis } = usePreset();
-  return useRefCallback(params => uploadFile(Object.assign({}, params, { apis: params?.apis || apis })));
+  const fileSystem = useFileSystemContext();
+  return useRefCallback(params => {
+    const hasExplicitDir = params && (params.directory !== undefined || params.path !== undefined);
+    return uploadFile(
+      Object.assign({}, !hasExplicitDir && fileSystem ? { directory: fileSystem.uploadPath } : null, params, {
+        apis: params?.apis || apis
+      })
+    );
+  });
 };
 
 export default uploadFile;

--- a/src/components/FileUpload/useFileUpload.js
+++ b/src/components/FileUpload/useFileUpload.js
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import createDeferred from '@kne/create-deferred';
 import { useContext, usePreset } from '@kne/global-context';
 import useRefCallback from '@kne/use-ref-callback';
@@ -7,6 +7,7 @@ import uniqueId from 'lodash/uniqueId';
 import { createIntl } from '@kne/react-intl';
 import computedAccept from './computedAccept';
 import { uploadFile } from './uploadFile';
+import { useFileSystemContext } from '../FileSystem/FileSystemContext';
 
 const formatAcceptLabel = accept => {
   if (!accept) {
@@ -22,6 +23,7 @@ const formatAcceptLabel = accept => {
 const useFileUpload = p => {
   const { locale } = useContext();
   const { formatMessage } = createIntl({ locale, namespace: 'react-file' });
+  const fileSystem = useFileSystemContext();
   const { multiple, fileSize, maxLength, value, concurrentCount, accept, onAdd, onError, onSave, onChange, onUpload, directory } = Object.assign(
     {},
     {
@@ -35,6 +37,9 @@ const useFileUpload = p => {
     p
   );
 
+  // 未显式传 directory 时，自动使用 FileSystem 当前上传目录（含分栏展开路径）
+  const resolvedDirectory = directory !== undefined ? directory : fileSystem?.uploadPath;
+
   const { apis } = usePreset();
   const { message } = App.useApp();
   const [uploadingList, setUploadingList] = useState([]);
@@ -42,6 +47,8 @@ const useFileUpload = p => {
     return createDeferred(concurrentCount);
   }, [concurrentCount]);
   const acceptLabel = useMemo(() => formatAcceptLabel(accept), [accept]);
+  const directoryRef = useRef(resolvedDirectory);
+  directoryRef.current = resolvedDirectory;
 
   const onFileSelected = useRefCallback(async fileList => {
     const allowCount = maxLength - value.length;
@@ -112,7 +119,7 @@ const useFileUpload = p => {
           const { data } = await deferred(() =>
             uploadFile({
               file,
-              directory,
+              directory: directoryRef.current,
               onUpload,
               apis
             })

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,6 @@ export { default as Image } from './components/Image';
 export { default as PrintButton } from './components/PrintButton';
 export { default as FileList, OptionButtons as FileListOptionButtons } from './components/FileList';
 export { default as FileUpload, FileInput, useFileUpload, uploadFile, useUploadFile, defaultAccept, computedAccept } from './components/FileUpload';
-export { default as FileSystem, PropertiesPanel, EntryIcon, calcPageSize } from './components/FileSystem';
+export { default as FileSystem, PropertiesPanel, EntryIcon, calcPageSize, useFileSystemContext } from './components/FileSystem';
 export { default as withOSSFile } from './hocs/withOSSFile';
 export { default as preset, globalParams } from './preset';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

1. 虚拟列表空白占位（未加载条目）hover 时仍显示单元格高亮，不符合预期。
2. 进入某一文件夹后上传文件，却落到根目录。

## 修复

### 1. 空白占位不响应 hover
- 列表 / 图标 / 分栏 / 画廊虚拟视图为空槽、骨架增加 `is-placeholder`
- SCSS 仅对非占位项应用 `:hover`，占位项 `pointer-events: none`

### 2. 上传目录跟随当前文件夹
- `FileSystem` 提供 `FileSystemContext`（`currentPath` + `uploadPath`）
- 分栏单击展开时，`uploadPath` 取最深展开目录（不仅是导航 `currentPath`）
- `FileUpload` / `useUploadFile` 未显式传 `directory` 时自动使用 `uploadPath`
- `uploadFile` 兼容 `path` 别名，避免只传 `path` 被忽略而落到根目录
- `toolbarExtra` 回调增加 `uploadPath`；示例改为使用 `FileUpload`

## 测试

- `npx jest` 全量通过（含新增 `uploadFile` 单测）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a74c5d57-16e4-4da7-932b-a10dd468cff6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a74c5d57-16e4-4da7-932b-a10dd468cff6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

