### PR TITLE
chore: 升级 @ant-design/icons 至 ^6.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.3.2",
     "@docmentis/udoc-viewer": "^0.7.16",
     "@extend-ai/react-docx": "^0.7.1",
     "@extend-ai/react-xlsx": "^0.10.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将 `@ant-design/icons` 从 `^5.5.1` 升级到 `^6.3.2`。

已校验本库使用的全部图标在 6.x 中均存在；单测通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a74c5d57-16e4-4da7-932b-a10dd468cff6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a74c5d57-16e4-4da7-932b-a10dd468cff6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

