### PR TITLE
chore: 升版本至 0.1.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/react-file",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "React文件操作组件库，提供文件上传、多格式预览、下载、列表管理及文件系统浏览，支持i18n",
   "syntax": {
     "esmodules": true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 版本

`0.1.58` → `0.1.59`

## 原因

按 `development-workflow`：升依赖须同步 patch 升本包 `version`。

#60 已合入 `@ant-design/icons@^6.3.2`，但未升本包版本，导致发布流水线报错 `You cannot publish over the previously published versions: 0.1.58`。

本次仅补版本号，以便 CI 发布含 icons 6.x 的包。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a74c5d57-16e4-4da7-932b-a10dd468cff6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a74c5d57-16e4-4da7-932b-a10dd468cff6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

